### PR TITLE
Update ngx_http_upstream_check_module.c

### DIFF
--- a/src/http/ngx_http_upstream_check_module.c
+++ b/src/http/ngx_http_upstream_check_module.c
@@ -1815,6 +1815,9 @@ ngx_http_upstream_check_recv_handler(ngx_event_t *event)
 
     if (peer->state != NGX_HTTP_CHECK_SEND_DONE) {
 
+        if(ngx_http_upstream_check_peek_one_byte(c) != NGX_OK) {
+            goto check_recv_fail;
+        }
         if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
             goto check_recv_fail;
         }


### PR DESCRIPTION
设备能通，但服务端口不通时，立即检测到失败，不用再等超时失败
