### PR TITLE
Update ngx_http_upstream_check_module.c

### DIFF
--- a/src/http/ngx_http_upstream_check_module.c
+++ b/src/http/ngx_http_upstream_check_module.c
@@ -1786,6 +1786,14 @@ ngx_http_upstream_check_send_handler(ngx_event_t *event)
         ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0, "http check send done.");
         peer->state = NGX_HTTP_CHECK_SEND_DONE;
         c->requests++;
+        
+        if(c->read->ready == 1) {
+            c->read->active = 0;
+            c->read->ready = 0;
+            if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
+                goto check_send_fail;
+            }
+        }
     }
 
     return;


### PR DESCRIPTION
通过greeting信息检查mysql，连接后read->handler可能早于write->handler，此时因为peer->state==NGX_HTTP_CHECK_CONNECT_DONE而read handler会不做事情，确保write handler后能再read
